### PR TITLE
Rearrange parameters to fix PHP warning

### DIFF
--- a/library/Netbox/Netbox.php
+++ b/library/Netbox/Netbox.php
@@ -178,7 +178,7 @@ class Netbox
 	// number of results; this is useful for testing.
 
 	//  VM's
-	public function virtualMachines(int $limit = 0, $filter)
+	public function virtualMachines($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "status=active";
@@ -186,7 +186,7 @@ class Netbox
 		return $this->get_netbox("/virtualization/virtual-machines/?" . $filter, $limit);
 	}
 
-	public function clusters(int $limit = 0, $filter)
+	public function clusters($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "status=active";
@@ -194,7 +194,7 @@ class Netbox
 		return $this->get_netbox("/virtualization/clusters/?" . $filter, $limit);
 	}
 
-	public function clusterGroups(int $limit = 0, $filter)
+	public function clusterGroups($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -202,7 +202,7 @@ class Netbox
 		return $this->get_netbox("/virtualization/cluster-groups/?" . $filter, $limit);
 	}
 
-	public function clusterTypes(int $limit = 0, $filter)
+	public function clusterTypes($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -211,7 +211,7 @@ class Netbox
 	}
 
 	// Devices
-	public function devices(int $limit = 0, $filter)
+	public function devices($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "status=active";
@@ -219,7 +219,7 @@ class Netbox
 		return $this->get_netbox("/dcim/devices/?" . $filter, $limit);
 	}
 
-	public function deviceRoles(int $limit = 0, $filter)
+	public function deviceRoles($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -227,7 +227,7 @@ class Netbox
 		return $this->get_netbox("/dcim/device-roles/?" . $filter, $limit);
 	}
 
-	public function deviceTypes(int $limit = 0, $filter)
+	public function deviceTypes($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -236,7 +236,7 @@ class Netbox
 	}
 
 	// IPAM 
-	public function ipAddresses(int $limit = 0, $filter)
+	public function ipAddresses($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "assigned_to_interface=True";
@@ -245,7 +245,7 @@ class Netbox
 	}
 
 	// Where
-	public function locations(int $limit = 0, $filter)
+	public function locations($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -253,7 +253,7 @@ class Netbox
 		return $this->get_netbox("/dcim/locations/?" . $filter, $limit);
 	}
 
-	public function sites(int $limit = 0, $filter)
+	public function sites($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "status=active";
@@ -261,7 +261,7 @@ class Netbox
 		return $this->get_netbox("/dcim/sites/?" . $filter, $limit);
 	}
 
-	public function siteGroups(int $limit = 0, $filter)
+	public function siteGroups($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -269,7 +269,7 @@ class Netbox
 		return $this->get_netbox("/dcim/site-groups/?" . $filter, $limit);
 	}
 
-	public function regions(int $limit = 0, $filter)
+	public function regions($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -278,7 +278,7 @@ class Netbox
 	}
 
 	// Who
-	public function tenants(int $limit = 0, $filter)
+	public function tenants($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -286,7 +286,7 @@ class Netbox
 		return $this->get_netbox("/tenancy/tenants/?" . $filter, $limit);
 	}
 
-	public function tenantGroups(int $limit = 0, $filter)
+	public function tenantGroups($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -295,7 +295,7 @@ class Netbox
 	}
 
 	// Other
-	public function platforms(int $limit = 0, $filter)
+	public function platforms($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "status=active";
@@ -304,7 +304,7 @@ class Netbox
 	}
 
 
-	public function tags(int $limit = 0, $filter)
+	public function tags($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "";
@@ -313,7 +313,7 @@ class Netbox
 	}
 
 	// Don't exclude inactive services for now, not sure what a inactive service on a active host will do
-	public function allservices(int $limit = 0, $filter)
+	public function allservices($filter, int $limit = 0)
 	{
 		if (empty($filter)) {
 			$filter = "status=active";

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -211,54 +211,54 @@ class ImportSource extends ImportSourceHook
 			// VM's
 			case self::VMMode:
 				$services = $netbox->allservices(0, "");
-				$devices = $netbox->virtualMachines($limit, $filter);
+				$devices = $netbox->virtualMachines($filter, $limit);
 				return $this->devices_with_services($services, $devices);
 			case self::ClusterMode:
-				return $netbox->clusters($limit, $filter);
+				return $netbox->clusters($filter, $limit);
 			case self::ClusterGroupMode:
-				return $netbox->clusterGroups($limit, $filter);
+				return $netbox->clusterGroups($filter, $limit);
 			case self::ClusterTypeMode:
-				return $netbox->clusterTypes($limit, $filter);
+				return $netbox->clusterTypes($filter, $limit);
 							
 			// Device
 			case self::DeviceMode:
 				$services = $netbox->allservices(0, "");
-				$devices = $netbox->devices($limit, $filter);
+				$devices = $netbox->devices($filter, $limit);
 				return $this->devices_with_services($services, $devices, $filter);
 			case self::DeviceRoleMode:
-				return $netbox->deviceRoles($limit, $filter);
+				return $netbox->deviceRoles($filter, $limit);
 			case self::DeviceTypeMode:
-				return $netbox->deviceTypes($limit, $filter);
+				return $netbox->deviceTypes($filter, $limit);
 
 			// IPAM
 			case self::IPAddressMode:
-				return $netbox->ipAddresses($limit, $filter);
+				return $netbox->ipAddresses($filter, $limit);
 
 			// Where			
 			case self::LocationMode:
-				return $netbox->locations($limit, $filter);
+				return $netbox->locations($filter, $limit);
 			case self::SiteMode:
-				return $netbox->sites($limit, $filter);
+				return $netbox->sites($filter, $limit);
 			case self::SiteGroupMode:
-				return $netbox->siteGroups($limit, $filter);
+				return $netbox->siteGroups($filter, $limit);
 			case self::RegionMode:
-				return $netbox->regions($limit, $filter);
+				return $netbox->regions($filter, $limit);
 
 			// Who
 			case self::TenantMode:
-				return $netbox->tenants($limit, $filter);
+				return $netbox->tenants($filter, $limit);
 			case self::TenantGroupMode:
-				return $netbox->tenantGroups($limit, $filter);
+				return $netbox->tenantGroups($filter, $limit);
 		
 			// Other
 			case self::PlatformMode:
-				return $netbox->platforms($limit, $filter);
+				return $netbox->platforms($filter, $limit);
 			case self::ServiceMode:
-				return $netbox->allservices($limit, $filter);
+				return $netbox->allservices($filter, $limit);
 			case self::TagMode:
-				return $netbox->tags($limit, $filter);
+				return $netbox->tags($filter, $limit);
 			case self::TestMode:
-				return $netbox->devices($limit, $filter);
+				return $netbox->devices($filter, $limit);
 			}
 	}
 

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -210,7 +210,7 @@ class ImportSource extends ImportSourceHook
 		switch ($mode) {
 			// VM's
 			case self::VMMode:
-				$services = $netbox->allservices(0, "");
+				$services = $netbox->allservices("", 0);
 				$devices = $netbox->virtualMachines($filter, $limit);
 				return $this->devices_with_services($services, $devices);
 			case self::ClusterMode:
@@ -222,7 +222,7 @@ class ImportSource extends ImportSourceHook
 							
 			// Device
 			case self::DeviceMode:
-				$services = $netbox->allservices(0, "");
+				$services = $netbox->allservices("", 0);
 				$devices = $netbox->devices($filter, $limit);
 				return $this->devices_with_services($services, $devices, $filter);
 			case self::DeviceRoleMode:


### PR DESCRIPTION
This fixes PHP deprecation warnings because an optional parameter was followed by a required one. 
This Message was displayed in the Web UI as well as the Icinga Director logs: `Deprecated: Required parameter $filter follows optional parameter $limit ...`.