### PR TITLE
Add support for importing interfaces

### DIFF
--- a/library/Netbox/Netbox.php
+++ b/library/Netbox/Netbox.php
@@ -210,6 +210,14 @@ class Netbox
 		return $this->get_netbox("/virtualization/cluster-types/?" . $filter, $limit);
 	}
 
+	public function virtualMachineInterfaces($filter, int $limit = 0)
+	{
+		if (empty($filter)) {
+			$filter = "";
+		}
+		return $this->get_netbox("/virtualization/interfaces/?" . $filter, $limit);
+	}
+
 	// Devices
 	public function devices($filter, int $limit = 0)
 	{
@@ -233,6 +241,14 @@ class Netbox
 			$filter = "";
 		}
 		return $this->get_netbox("/dcim/device-types/?" . $filter, $limit);
+	}
+
+	public function deviceInterfaces($filter, int $limit = 0)
+	{
+		if (empty($filter)) {
+			$filter = "";
+		}
+		return $this->get_netbox("/dcim/interfaces/?" . $filter, $limit);
 	}
 
 	// IPAM 

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -16,11 +16,13 @@ class ImportSource extends ImportSourceHook
 	const ClusterMode = 12;
 	const ClusterTypeMode = 14;
 	const VMMode = 16;
+	const VMInterfaceMode = 18;
 
 	// Device
 	const DeviceMode = 20;
 	const DeviceRoleMode = 22;
 	const DeviceTypeMode = 24;
+	const DeviceInterfaceMode = 26;
 
 	// IPAM
 	const IPAddressMode = 30;
@@ -144,11 +146,13 @@ class ImportSource extends ImportSourceHook
 				self::ClusterGroupMode => $form->translate('Cluster groups'),
 				self::ClusterTypeMode => $form->translate('Cluster types'),
 				self::VMMode => $form->translate('Virtual machines'),
+				self::VMInterfaceMode => $form->translate('Virtual machine interfaces'),
 			
 				// Device
 				self::DeviceMode => $form->translate('Devices'),
 				self::DeviceRoleMode => $form->translate('Device roles'),
 				self::DeviceTypeMode => $form->translate('Device types'),
+				self::DeviceInterfaceMode => $form->translate('Device interfaces'),
 			
 				// IPAM
 				self::IPAddressMode => $form->translate('IP Addresses'),
@@ -226,6 +230,8 @@ class ImportSource extends ImportSourceHook
 				return $netbox->clusterGroups($filter, $limit);
 			case self::ClusterTypeMode:
 				return $netbox->clusterTypes($filter, $limit);
+			case self::VMInterfaceMode:
+				return $netbox->virtualMachineInterfaces($filter, $limit);
 							
 			// Device
 			case self::DeviceMode:
@@ -236,6 +242,8 @@ class ImportSource extends ImportSourceHook
 				return $netbox->deviceRoles($filter, $limit);
 			case self::DeviceTypeMode:
 				return $netbox->deviceTypes($filter, $limit);
+			case self::DeviceInterfaceMode:
+				return $netbox->deviceInterfaces($filter, $limit);
 
 			// IPAM
 			case self::IPAddressMode:


### PR DESCRIPTION
This adds support for importing device and VM interfaces from NetBox into Icinga. It is useful for creating services to check interface on switches and routers.