### PR TITLE
fix missing string cast causing deprecated explode call

### DIFF
--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -128,9 +128,9 @@ class ImportSource extends ImportSourceHook
 	private function ip_in_range($lower_range_ip_address, $upper_range_ip_address, $needle_ip_address)
 	{
 		# Get the numeric reprisentation of the IP Address with IP2long
-		$min    = ip2long(explode('/', $lower_range_ip_address)[0]);
-		$max    = ip2long(explode('/', $upper_range_ip_address)[0]);
-		$needle = ip2long(explode('/', $needle_ip_address)[0]);
+		$min    = ip2long(explode('/', (string)$lower_range_ip_address)[0]);
+		$max    = ip2long(explode('/', (string)$upper_range_ip_address)[0]);
+		$needle = ip2long(explode('/', (string)$needle_ip_address)[0]);
 
 		return (($needle >= $min) AND ($needle <= $max));
 	}   


### PR DESCRIPTION
As from PHP 8.1, passing null to an explode call is deprecated and causes a warning being persistent is syslog.

Source: [PHP - Deprecated Features](https://www.php.net/manual/en/migration81.deprecated.php)
Example syslog entry: `Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /usr/share/icingaweb2/modules/netbox/library/Netbox/ProvidedHook/Director/ImportSource.php on line 133`

Fixed by adding string cast to respective explode calls.