### PR TITLE
minor change to set default _type, so sync rules can filter

### DIFF
--- a/library/Netbox/Netbox.php
+++ b/library/Netbox/Netbox.php
@@ -281,6 +281,7 @@ class Netbox
 				}
 				foreach ($other_keys as $o) {
 					$row->{'icinga_' . $o} = NULL;
+					$row->{'icinga_' . $o . '_type'} = NULL;
 				}
 
 				if (property_exists($row->config_context, 'icinga')) {
@@ -304,6 +305,7 @@ class Netbox
 					foreach ($other_keys as $okey) {
 						if (property_exists($icinga, $okey)) {
 							$row->{"icinga_" . $okey} = $icinga->{$okey};
+							$row->{"icinga_" . $okey . '_type'} = gettype($icinga->{$okey});
 						}
 					}	
 


### PR DESCRIPTION
Filter expressions in Director can only evaluate string or `NULL` types.

Before this PR, the `icinga_*` PHP variables could either be `NULL` (if empty or not set) or an object (if set), as described in the README.

This caused the filter expression to throw an error.

This change sets the `icinga_*_type` to `icinga_*` object's type as a string to avoid this issue.


 Fix for #34 #35 
