### PR TITLE
Contact role dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,11 @@ Services monitoring can be enhanced by the creation of 3 custom fields in Netbox
 - If `icinga_monitored` is created as a boolean custom field and it set to `false` the import module will exclude the service from all dicts
 
 ##### Contacts
-Creates the vars `contact_keyids` and `contacts`.
+Creates the vars `contact_keyids`, `contacts` and `contact_role_dicts`.
 
 - `contact_keyids` is a list of contact names in keyid format that are linked to the parent object, this is useful in apply rules when keyid is used as the Icinga contact object name
 - `contacts` is a list of contact name that are linked to the parent object
+- `contact_role_dicts` is a dict with role names as key and a list as value containing the role contacts assigned on the device
 
 ##### Interfaces
 Creates the vars `interfaces_down`, `interfaces_up`, `interfaces_down_dict` and `interfaces_up_dict`.

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -82,10 +82,20 @@ class ImportSource extends ImportSourceHook
 			// make an array here for a list of contacts
 			$thing->contacts = array();
 			$thing->contact_keyids = array();
+			$thing->contact_dicts = array();
 			foreach ($contact_assignments as $contact_assignment) {
 				if ($contact_assignment->object->id == $thing->id) {
-					array_push($thing->contacts, $contact_assignment->contact->name);
-					array_push($thing->contact_keyids, strtolower("nbcontact " . preg_replace('/__+/i', '_', preg_replace('/[^0-9a-zA-Z_\-. ]+/i', '_', $contact_assignment->contact->name))));
+					$name = $contact_assignment->contact->name;
+					$keyid = strtolower("nbcontact " . preg_replace('/__+/i', '_', preg_replace('/[^0-9a-zA-Z_\-. ]+/i', '_', $name)));
+					$role_name = isset($contact_assignment->role) ? $contact_assignment->role->name : null;
+
+					$thing->contacts[] = $name;
+					$thing->contact_keyids[] = $keyid;
+					$thing->contact_dicts[] = array(
+						"name" => $name,
+						"keyid" => $keyid,
+						"role" => $role_name
+					);
 				}
 			}
 			$output = array_merge($output, [(object)$thing]);

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -83,6 +83,7 @@ class ImportSource extends ImportSourceHook
 			$thing->contacts = array();
 			$thing->contact_keyids = array();
 			$thing->contact_dicts = array();
+			$thing->contact_role_dicts = array();
 			foreach ($contact_assignments as $contact_assignment) {
 				if ($contact_assignment->object->id == $thing->id) {
 					$name = $contact_assignment->contact->name;
@@ -91,11 +92,16 @@ class ImportSource extends ImportSourceHook
 
 					$thing->contacts[] = $name;
 					$thing->contact_keyids[] = $keyid;
-					$thing->contact_dicts[] = array(
-						"name" => $name,
-						"keyid" => $keyid,
-						"role" => $role_name
-					);
+
+					if (!isset($thing->contact_role_dicts[$role_name])) {
+            $thing->contact_role_dicts[$role_name] = array();
+          }
+          array_push($thing->contact_role_dicts[$role_name], $name);
+
+					if (!isset($thing->contact_role_dicts[$role_name . "_keyids"])) {
+            $thing->contact_role_dicts[$role_name . "_keyids"] = array();
+          }
+					array_push($thing->contact_role_dicts[$role_name . "_keyids"], $keyid);
 				}
 			}
 			$output = array_merge($output, [(object)$thing]);


### PR DESCRIPTION
This PR creates a new column `contact_role_dicts`. The structure within the column is the following:

```
{
  role_1: [
    "contact_1",
    "contact_2"
  ],
  role_1_keyids: [
    "nbcontact contact_1",
    "nbcontact contact_2"
  ]
}
```

The column can be combined with the _Get a specific Array Element_ filter in icinga to get the list of contact with a specific role. Background is the separation between f.e. sms and mail notifications. Combined with [these scripts](https://github.com/Icinga/icinga2/blob/master/etc/icinga2/scripts/mail-host-notification.sh) the contacts can be taken out of a variable and be used for the notification. 

The whole process has been tested with netbox 4.3.1 but should be compatible with older netbox versions as well. 