### PR TITLE
add column for parent platform

### DIFF
--- a/library/Netbox/Netbox.php
+++ b/library/Netbox/Netbox.php
@@ -728,6 +728,7 @@ class Netbox
 	{
 		$this->object_type = 'platform';
 		$this->type_map = array(
+			"parent" => "platform",
 			"manufacturer" => "manufacturer"
 		);
 		return $this->get_netbox("/dcim/platforms/?" . $this->default_filter($filter, "status=active"), $limit);


### PR DESCRIPTION
I would like to use the platform hierarchy, to apply services to each of these levels.  
For example: Linux > Debian > Proxmox.

To make this possible, I add the *keyid* to the parent platform.
