### PR TITLE
keyid based on slug

### DIFF
--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -1,13 +1,18 @@
 <?php
-namespace Icinga\Module\Clustergraph\Controllers;
+namespace Icinga\Module\Netbox\Controllers;
 
 use Icinga\Application\Config;
-use Icinga\Forms\ConfigForm;
 use Icinga\Web\Controller;
 use Icinga\Module\Netbox\Forms\Config\ConfigForm;
 
-class Netbox_ConfigController extends Controller
+class ConfigController extends Controller
 {
+    public function init(): void
+    {
+        $this->assertPermission('config/modules');
+        parent::init();
+    }
+
     public function indexAction()
     {
         // Load (or create) the module's config.ini
@@ -18,5 +23,6 @@ class Netbox_ConfigController extends Controller
         $form->handleRequest();
 
         $this->view->form = $form;
+        $this->view->tabs = $this->Module()->getConfigTabs()->activate('config');
     }
 }

--- a/application/forms/Config/ConfigForm.php
+++ b/application/forms/Config/ConfigForm.php
@@ -15,27 +15,30 @@ class ConfigForm extends BaseConfigForm
 
     public function createElements(array $formData)
     {
-        $this->addElement('text', 'baseurl', [
+        $this->addElement('text', 'netbox_baseurl', [
             'label'       => $this->translate('NetBox API URL'),
             'description' => $this->translate('Base URL to the Netbox API, e.g. https://netbox.example.com/api'),
+            'placeholder' => 'https://netbox.example.com/api',
+            'required'    => true,
         ]);
 
-        $this->addElement('password', 'apitoken', [
+        $this->addElement('password', 'netbox_apitoken', [
             'label'       => $this->translate('API Token'),
             'description' => $this->translate('See https://netbox.example.com/user/api-tokens'),
+            'required'    => true,
         ]);
 
-        $this->addElement('text', 'proxy', [
+        $this->addElement('text', 'netbox_proxy', [
             'label'       => $this->translate('Proxy'),
             'description' => $this->translate('Optional proxy server setting in the format <address>:<port>'),
         ]);
 
-        $this->addElement('checkbox', 'ssl_enable', [
+        $this->addElement('checkbox', 'netbox_ssl', [
             'label' => $this->translate('Enable SSL checks'),
             'description' => $this->translate('Checking this box will cause the Netbox import module enable SSL certificate verification and SSL hostname check.'),
         ]);
 
-        $this->addElement('checkbox', 'slug_keyids', [
+        $this->addElement('checkbox', 'netbox_slug', [
             'label'       => $this->translate('Slug keyid\'s'),
             'description' => $this->translate('Where available use slugs for keyid\'s.'),
         ]);

--- a/application/views/scripts/config/index.phtml
+++ b/application/views/scripts/config/index.phtml
@@ -1,0 +1,6 @@
+<div class="controls">
+    <?= /** @var \Icinga\Web\Widget\Tabs $tabs */ $tabs ?>
+</div>
+<div class="content">
+    <?= /** @var \Icinga\Module\Netbox\Forms\ConfigForm $form */ $form ?>
+</div>

--- a/library/Netbox/Netbox.php
+++ b/library/Netbox/Netbox.php
@@ -2,6 +2,7 @@
 
 namespace Icinga\Module\Netbox;
 
+use Icinga\Application\Config;
 // use Icinga\Module\Director\Daemon\Logger;
 
 class Netbox
@@ -36,6 +37,22 @@ class Netbox
 		$this->flattenkeys = $flattenkeys;
 		$this->munge = $munge;
 		$this->slug = $slug;
+	}
+
+	public static function fromConfig($baseurl = '', $token = '', $proxy = '', $sslenable = '', $flattenseparator = '', $flattenkeys = '', $munge = '')
+	{
+		$config = Config::module('netbox');
+
+        return new Netbox(
+            (($baseurl != '') ? $baseurl : $config->get('netbox', 'baseurl')),
+            (($token != '') ? $token : $config->get('netbox', 'apitoken')),
+            (($proxy != '') ? $proxy : $config->get('netbox', 'proxy')),
+            (($sslenable != '') ? $sslenable : $config->get('netbox', 'ssl')),
+            $flattenseparator,
+            $flattenkeys,
+            $munge,
+            $config->get('netbox', 'slug')
+        );
 	}
 
 	private function httpget(string $url)

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -515,7 +515,7 @@ class ImportSource extends ImportSourceHook
 
 	private function getLinkedObjects($baseurl, $apitoken, $proxy, $sslenable, $linkservices, $linkcontacts, $linkinterfaces, $content_type, $things)
 	{
-		$netboxLinked = new Netbox($baseurl, $apitoken, $proxy, $sslenable, "", "", "");
+		$netboxLinked = Netbox::fromConfig($baseurl, $apitoken, $proxy, $sslenable);
 		$services = array();
 		if ($linkservices) {
 			$services = $netboxLinked->allservices("", 0);
@@ -569,7 +569,7 @@ class ImportSource extends ImportSourceHook
 		$parsealldataforlistcolumns = $this->getSetting('parse_all_data_for_listcolumns');
 		$linkinterfaces = $this->getSetting('linked_interfaces');
 		$sslenable = $this->getSetting('ssl_enable');
-		$netbox = new Netbox($baseurl, $apitoken, $proxy, $sslenable, $flatten, $flattenkeys, $munge);
+		$netbox = Netbox::fromConfig($baseurl, $apitoken, $proxy, $sslenable, $flatten, $flattenkeys, $munge);
 
 		if ($parsealldataforlistcolumns) {
 			// We need to set the limit to 0 to parse the data from Netbox and create column headings 

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -365,21 +365,26 @@ class ImportSource extends ImportSourceHook
 
 	public static function addSettingsFormFields(QuickForm $form)
 	{
+		$global_config = Config::module('netbox');
+
+		$global_baseurl = $global_config->get('netbox', 'baseurl');
 		$form->addElement('text', 'baseurl', array(
 			'label' => $form->translate('Base URL'),
-			'required' => true,
+			'required' => ($global_baseurl == ''),
+			'placeholder' => ($global_baseurl != '' ? $global_baseurl : 'https://netbox.example.com/api'),
 			'description' => $form->translate('Base URL to the Netbox API, e.g. https://netbox.example.com/api')
 		));
 
 		$form->addElement('text', 'apitoken', array(
 			'label' => $form->translate('API token'),
-			'required' => true,
+			'required' => ($global_config->get('netbox', 'apitoken') == ''),
 			'description' => $form->translate('See https://netbox.example.com/user/api-tokens')
 		));
 
 		$form->addElement('text', 'proxy', array(
 			'label' => $form->translate('Proxy'),
 			'required' => false,
+			'placeholder' => $global_config->get('netbox', 'proxy'),
 			'description' => $form->translate('Optional proxy server setting in the format <address>:<port>')
 		));
 


### PR DESCRIPTION
I would like to have pretty object names in Icinga.  
In my opinion, the *slug* attribute is more suitable for this than the *name*.
I have extended the key generation so that the slug is used if available. It can be activated with an option in the import source configuration.

However, I am not (yet) sure whether the additional parameter in the import source is a good idea.