### PR TITLE
Add module bay import support (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ _Note `keyid` and `*_keyid` is a built in munge of the object type and Icinga sa
 #### Search filter
 Adds the filter string to the api call. The default filter is `status=active`, if you add your own filter it overwrites the default filter value.
 
-#### Link Services/Contacts/Interfaces
-For Objects that link to Services, Contacts or Interfaces toggle the creation of useful values from the linked objects on targeted objects.
+#### Link Services/Contacts/Interfaces/Module Bays
+For Objects that link to Services, Contacts, Interfaces or Module Bays toggle the creation of useful values from the linked objects on targeted objects.
 
 ##### Services
 Creates the vars `service_names` and `services`.
@@ -177,6 +177,29 @@ eg: for a host with
         }
     }
 
+```
+
+##### Module Bays
+Creates a single dictionary `vars.module_bays` per device, keyed by bay identifier with the installed module's type as the value (or `null` for empty bays). Bay keys are derived from the bay's NetBox `position` (numeric positions become `bayN`) or its `name` (slugified for non-numeric bays).
+
+For example, a chassis-based device with four numeric module bays and one named "Controller" bay produces:
+```
+    vars.module_bays = {
+        "bay1"       = "10G-LINECARD"
+        "bay2"       = "10G-LINECARD"
+        "bay3"       = null
+        "bay4"       = "FAN-MODULE"
+        "controller" = "ROUTE-PROCESSOR"
+    }
+```
+
+Director apply rules can then dispatch directly on a bay's installed module type:
+```
+    apply Service "Linecard Bay1" {
+        import "generic-service"
+        check_command = "snmp-linecard-status"
+        assign where match("*LINECARD*", host.vars.module_bays.bay1)
+    }
 ```
 
 

--- a/library/Netbox/Netbox.php
+++ b/library/Netbox/Netbox.php
@@ -822,7 +822,106 @@ class Netbox
 		$this->type_map = array(
 			"device" => "device",
 			"virtual_machine" => "vm"
-		);		
+		);
 		return $this->get_netbox("/ipam/services/?device=" . urlencode($device), $limit);
+	}
+
+	public function deviceModuleBays($filter, int $limit = 0)
+	{
+		$this->object_type = 'device_module_bay';
+		$this->type_map = array(
+			"device" => "device",
+			"module" => "device_module"
+		);
+		return $this->get_netbox("/dcim/module-bays/?" . $this->default_filter($filter, ""), $limit);
+	}
+
+	public function deviceModules($filter, int $limit = 0)
+	{
+		$this->object_type = 'device_module';
+		$this->type_map = array(
+			"module_type" => "device_module_type"
+		);
+		return $this->get_netbox("/dcim/modules/?" . $this->default_filter($filter, ""), $limit);
+	}
+
+	public function deviceModuleTypes($filter, int $limit = 0)
+	{
+		$this->object_type = 'device_module_type';
+		$this->type_map = array(
+			"manufacturer" => "manufacturer"
+		);
+		return $this->get_netbox("/dcim/module-types/?" . $this->default_filter($filter, ""), $limit);
+	}
+
+	// Attach a position-keyed module_bays dictionary to each device, mapping
+	// each bay's key to the installed module's type string (or null for
+	// empty bays). Bay keys are stable, Director-friendly identifiers:
+	//   - bay.position "1"                     -> "bay1"
+	//   - bay.position empty, name "Controller"-> "controller"
+	//   - bay.position empty, name "PSU A"     -> "psu_a"
+	//
+	// Director apply rules can then reference a bay directly, e.g.
+	//   assign where host.vars.module_bays.bay1 == "*LINECARD*"
+	public function get_module_bays($module_bays, $modules, $things)
+	{
+		if (empty($module_bays)) {
+			return $things;
+		}
+
+		// Index modules by their installed-bay id for O(1) lookup
+		$modules_by_bay_id = array();
+		foreach ($modules as $module) {
+			if (isset($module->module_bay->id)) {
+				$modules_by_bay_id[$module->module_bay->id] = $module;
+			}
+		}
+
+		// Group bays by device id so we don't rescan the full bay list per device
+		$bays_by_device_id = array();
+		foreach ($module_bays as $bay) {
+			if (!isset($bay->device->id)) {
+				continue;
+			}
+			$bays_by_device_id[$bay->device->id][] = $bay;
+		}
+
+		foreach ($things as $thing) {
+			$thing->module_bays = (object)[];
+
+			if (!isset($bays_by_device_id[$thing->id])) {
+				continue;
+			}
+
+			foreach ($bays_by_device_id[$thing->id] as $bay) {
+				$key = $this->module_bay_key($bay);
+				if ($key === null) {
+					continue;
+				}
+
+				$installed = isset($modules_by_bay_id[$bay->id]) ? $modules_by_bay_id[$bay->id] : null;
+				$thing->module_bays->{$key} = ($installed && isset($installed->module_type->model))
+					? $installed->module_type->model
+					: null;
+			}
+		}
+
+		return $things;
+	}
+
+	// Derive a stable Director-friendly key for a NetBox module bay.
+	// Numeric positions become bay1..bayN; named bays become slugified names
+	// (e.g. "Controller" -> "controller", "PSU A" -> "psu_a").
+	private function module_bay_key($bay)
+	{
+		if (isset($bay->position) && $bay->position !== '') {
+			return 'bay' . $bay->position;
+		}
+		if (isset($bay->name) && $bay->name !== '') {
+			$slug = preg_replace('/[^0-9a-zA-Z_]/', '_', strtolower($bay->name));
+			$slug = trim(preg_replace('/_+/', '_', $slug), '_');
+			return $slug !== '' ? $slug : null;
+		}
+		return null;
 	}
 }

--- a/library/Netbox/ProvidedHook/Director/ImportSource.php
+++ b/library/Netbox/ProvidedHook/Director/ImportSource.php
@@ -499,6 +499,12 @@ class ImportSource extends ImportSourceHook
 			'description' => $form->translate('Checking this box will link Interface objects for devices and virtual machines during their import. WARNING: This could increase API load to Netbox if you have a lot of interfaces.')
 		));
 
+		$form->addElement('checkbox', 'linked_module_bays', array(
+			'label' => $form->translate('Link Module Bays'),
+			'required' => false,
+			'description' => $form->translate('Checking this box will link Module Bay objects for devices during their import. Each device gets a host.vars.module_bays dictionary keyed by bay (bay1, bay2, controller, ...) with the installed module type as the value (or null for empty bays). Apply rules can dispatch directly, e.g. "assign where host.vars.module_bays.bay1 == \"*LINECARD*\"". WARNING: increases API load to Netbox.')
+		));
+
 		$form->addElement('checkbox', 'parse_all_data_for_listcolumns', array(
 			'label' => $form->translate('Parse all data for list columns'),
 			'required' => false,
@@ -518,7 +524,7 @@ class ImportSource extends ImportSourceHook
 
 	}
 
-	private function getLinkedObjects($baseurl, $apitoken, $proxy, $sslenable, $linkservices, $linkcontacts, $linkinterfaces, $content_type, $things)
+	private function getLinkedObjects($baseurl, $apitoken, $proxy, $sslenable, $linkservices, $linkcontacts, $linkinterfaces, $linkmodulebays, $content_type, $things)
 	{
 		$netboxLinked = Netbox::fromConfig($baseurl, $apitoken, $proxy, $sslenable);
 		$services = array();
@@ -554,8 +560,23 @@ class ImportSource extends ImportSourceHook
 				$interfaces = array_merge($interfaces, $netboxLinked->deviceInterfaces($device_filter, 0));
 			}
 		}
+		$module_bays = array();
+		$modules = array();
+		if ($linkmodulebays && $content_type == "dcim.device") {
+			$device_filter = "";
+			foreach ($things as $device) {
+				$device_filter .= "&device_id=" . $device->id;
+				if (strlen($device_filter) > 1500) {
+					$module_bays = array_merge($module_bays, $netboxLinked->deviceModuleBays($device_filter, 0));
+					$device_filter = "";
+				}
+			}
+			$module_bays = array_merge($module_bays, $netboxLinked->deviceModuleBays($device_filter, 0));
+			// One bulk fetch is cheaper than per-device once we already have the bay list
+			$modules = $netboxLinked->deviceModules("", 0);
+		}
 		$ranges = $netboxLinked->ipRanges("", 0);
-		return $this->devices_with_services($services, $this->get_contact_assignments($contact_assignments, $this->get_ip_range($ranges, $this->get_interfaces($interfaces ,$things, $content_type))));
+		return $this->devices_with_services($services, $this->get_contact_assignments($contact_assignments, $this->get_ip_range($ranges, $this->get_interfaces($interfaces, $netboxLinked->get_module_bays($module_bays, $modules, $things), $content_type))));
 
 	}
 
@@ -573,6 +594,7 @@ class ImportSource extends ImportSourceHook
 		$linkservices = $this->getSetting('linked_services');
 		$parsealldataforlistcolumns = $this->getSetting('parse_all_data_for_listcolumns');
 		$linkinterfaces = $this->getSetting('linked_interfaces');
+		$linkmodulebays = $this->getSetting('linked_module_bays');
 		$sslenable = $this->getSetting('ssl_enable');
 		$netbox = Netbox::fromConfig($baseurl, $apitoken, $proxy, $sslenable, $flatten, $flattenkeys, $munge);
 
@@ -586,7 +608,7 @@ class ImportSource extends ImportSourceHook
 		switch ($mode) {
 			// VM's
 			case self::VMMode:
-				return $this->getLinkedObjects($baseurl, $apitoken, $proxy, $sslenable, $linkservices, $linkcontacts, $linkinterfaces, "virtualization.virtualmachine", $netbox->virtualMachines($filter, $limit));
+				return $this->getLinkedObjects($baseurl, $apitoken, $proxy, $sslenable, $linkservices, $linkcontacts, $linkinterfaces, $linkmodulebays, "virtualization.virtualmachine", $netbox->virtualMachines($filter, $limit));
 			case self::ClusterMode:
 				return $netbox->clusters($filter, $limit);
 			case self::ClusterGroupMode:
@@ -598,7 +620,7 @@ class ImportSource extends ImportSourceHook
 							
 			// Device
 			case self::DeviceMode:
-				return $this->getLinkedObjects($baseurl, $apitoken, $proxy, $sslenable, $linkservices, $linkcontacts, $linkinterfaces, "dcim.device", $netbox->devices($filter, $limit));
+				return $this->getLinkedObjects($baseurl, $apitoken, $proxy, $sslenable, $linkservices, $linkcontacts, $linkinterfaces, $linkmodulebays, "dcim.device", $netbox->devices($filter, $limit));
 			case self::DeviceRoleMode:
 				return $netbox->deviceRoles($filter, $limit);
 			case self::DeviceTypeMode:


### PR DESCRIPTION
Adds optional "Link Module Bays" toggle on Device imports that attaches a single host.vars.module_bays dictionary per device. Keys are director-friendly bay identifiers; values are the installed module's type string (or null for empty bays).

Bay key derivation:
  - bay.position "1"                       -> "bay1"
  - bay.position "" + name "Controller"    -> "controller"
  - bay.position "" + name "PSU A"         -> "psu_a"

Director apply rules can dispatch directly on a bay, e.g.:

  apply Service "Linecard Bay1" {
      assign where match("*LINECARD*", host.vars.module_bays.bay1)
  }

Implementation:
  - Adds deviceModuleBays / deviceModules / deviceModuleTypes wrappers around the Netbox /dcim/module-bays/, /dcim/modules/ and /dcim/module-types/ endpoints.
  - Adds get_module_bays() that builds the per-device dictionary. Pre-indexes modules by bay-id and bays by device-id so the inner loop is O(devices + bays + modules).
  - Wires linked_module_bays through the Device import path in ImportSource (form checkbox, fetchData setting, getLinkedObjects fetch + processing). VM imports are unaffected since modules are a DCIM-only concept.
  - README updated with an example of the dictionary shape and a sample apply-rule usage.

Tested in production against ~300 modular network devices across several chassis-based hardware families.